### PR TITLE
Support ES6 tagged template literals

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -1,0 +1,18 @@
+" Prologue; load in GraphQL syntax.
+if exists('b:current_syntax')
+  let s:current_syntax=b:current_syntax
+  unlet b:current_syntax
+endif
+syn include @GraphQLSyntax syntax/graphql.vim
+if exists('s:current_syntax')
+  let b:current_syntax=s:current_syntax
+endif
+
+syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,jsTemplateVar,jsSpecial extend
+exec 'syntax match graphqlTaggedTemplate +\%(' . join(g:graphql_tag_names, '\|') . '\)\%(`\)\@=+ nextgroup=graphqlTemplateString'
+
+hi def link graphqlTemplateString           jsTemplateString
+hi def link graphqlTaggedTemplate           jsTaggedTemplate
+
+syn cluster jsExpression add=graphqlTaggedTemplate
+syn cluster graphqlTaggedTemplate add=graphqlTemplateString

--- a/plugin/graphql.vim
+++ b/plugin/graphql.vim
@@ -1,0 +1,3 @@
+if (!exists('g:graphql_tag_names'))
+  let g:graphql_tag_names = ['gql', 'graphql']
+endif


### PR DESCRIPTION
This patch adds support for GraphQL syntax in ES6 tagged template literals. (As used by `graphql-tag`, for example.) By default, GraphQL syntax is highlighted in template literals tagged with `gql` or `graphql`. This can be configured via the `g:graphql_tag_names` array.